### PR TITLE
Add danbooru prompt generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # TEST
+
 テスト
+
+This repository contains a simple script to help generate Stable Diffusion prompts
+using danbooru-style tags.
+
+## Usage
+
+Run the script with a description of the desired image:
+
+```bash
+python danbooru_prompt_app.py "A smiling girl with long hair and blue eyes"
+```
+
+The script will output a comma-separated list of tags that can be used as a
+prompt for Stable Diffusion.

--- a/danbooru_prompt_app.py
+++ b/danbooru_prompt_app.py
@@ -1,0 +1,80 @@
+import argparse
+import re
+
+# Mapping from words to danbooru tags
+WORD_TAGS = {
+    "girl": "1girl",
+    "boy": "1boy",
+    "smile": "smile",
+    "smiling": "smile",
+    "happy": "smile",
+    "weapon": "weapon",
+    "sword": "sword",
+    "gun": "gun",
+    "cat": "cat",
+    "dog": "dog",
+    "tree": "tree",
+    "outdoor": "outdoors",
+    "indoor": "indoors",
+    "standing": "standing",
+    "sitting": "sitting",
+    "blush": "blush",
+    "blushing": "blush",
+}
+
+# Mapping from multi-word phrases to danbooru tags
+PHRASE_TAGS = {
+    "long hair": "long_hair",
+    "short hair": "short_hair",
+    "blue eyes": "blue_eyes",
+    "red eyes": "red_eyes",
+    "green eyes": "green_eyes",
+    "black hair": "black_hair",
+    "brown hair": "brown_hair",
+    "blonde hair": "blonde_hair",
+}
+
+def generate_prompt(text: str) -> str:
+    """Convert input text to a comma-separated list of danbooru tags."""
+    text = text.lower()
+    tags = []
+
+    # Detect phrases first
+    for phrase, tag in PHRASE_TAGS.items():
+        if phrase in text:
+            tags.append(tag)
+            text = text.replace(phrase, " ")
+
+    # Process single words
+    tokens = re.findall(r"\b\w+\b", text)
+    for token in tokens:
+        if token in WORD_TAGS:
+            tags.append(WORD_TAGS[token])
+
+    # Remove duplicates while preserving order
+    seen = set()
+    unique_tags = []
+    for tag in tags:
+        if tag not in seen:
+            seen.add(tag)
+            unique_tags.append(tag)
+
+    return ", ".join(unique_tags)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert text to danbooru tags for Stable Diffusion prompts")
+    parser.add_argument("text", nargs="*", help="Input description")
+    args = parser.parse_args()
+
+    if args.text:
+        input_text = " ".join(args.text)
+    else:
+        input_text = input("Enter description: ")
+
+    prompt = generate_prompt(input_text)
+    print(prompt)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `danbooru_prompt_app.py` for converting descriptions to danbooru tags
- update README with usage instructions

## Testing
- `python danbooru_prompt_app.py "A smiling girl with long hair and blue eyes"`
- `python danbooru_prompt_app.py` with interactive input

------
https://chatgpt.com/codex/tasks/task_e_68405e8bcbcc8325aadabecb07d6d673