### PR TITLE
Add spaCy-based danbooru tag converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,19 @@
 
 テスト
 
-This repository contains a simple script to help generate Stable Diffusion prompts
-using danbooru-style tags.
+This repository contains a simple script to help generate Stable Diffusion prompts using danbooru-style tags.
 
 ## Usage
 
-Run the script with a description of the desired image:
+There are two scripts available:
+
+1. **danbooru_prompt_app.py** - A basic word/phrase matcher.
+2. **tag_converter.py** - A spaCy based converter that reads tags from `tags.json`.
+
+Run the new converter with a description of the desired image:
 
 ```bash
-python danbooru_prompt_app.py "A smiling girl with long hair and blue eyes"
+python tag_converter.py "A happy girl with blue eyes and long hair"
 ```
 
-The script will output a comma-separated list of tags that can be used as a
-prompt for Stable Diffusion.
+The script will output a comma-separated list of tags that can be used as a prompt for Stable Diffusion.

--- a/tag_converter.py
+++ b/tag_converter.py
@@ -1,0 +1,115 @@
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import spacy
+
+# Load English model
+try:
+    nlp = spacy.load("en_core_web_sm")
+except OSError:
+    # Model not installed
+    nlp = spacy.blank("en")
+
+NEGATIONS = {"no", "not", "without", "n't"}
+
+CATEGORIES_ORDER = [
+    "person",
+    "hair",
+    "eyes",
+    "emotion",
+    "position",
+    "object",
+    "animal",
+    "environment",
+    "misc",
+]
+
+
+def load_tags(path: Path) -> Tuple[Dict[str, Dict[str, str]], Dict[str, Dict[str, str]]]:
+    """Load tag dictionaries from a JSON file."""
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("words", {}), data.get("phrases", {})
+
+
+def is_negated(token) -> bool:
+    """Return True if the token is negated in the sentence."""
+    if token.i > 0 and token.doc[token.i - 1].lower_ in NEGATIONS:
+        return True
+    # Check negation children or ancestors
+    for child in token.children:
+        if child.dep_ == "neg" or child.lower_ in NEGATIONS:
+            return True
+    for ancestor in token.ancestors:
+        for child in ancestor.children:
+            if child.dep_ == "neg" or child.lower_ in NEGATIONS:
+                return True
+    return False
+
+
+def extract_tags(text: str, word_tags: Dict[str, Dict[str, str]], phrase_tags: Dict[str, Dict[str, str]]) -> List[Tuple[str, str]]:
+    text_lower = text.lower()
+    doc = nlp(text_lower)
+    tokens_lower = [t.text.lower() for t in doc]
+    used = set()
+    tags: List[Tuple[str, str]] = []
+
+    # process phrases first, longer phrases first
+    phrases_sorted = sorted(phrase_tags.items(), key=lambda x: len(x[0].split()), reverse=True)
+    for phrase, info in phrases_sorted:
+        phrase_tokens = phrase.split()
+        length = len(phrase_tokens)
+        for i in range(len(doc) - length + 1):
+            if any((i + j) in used for j in range(length)):
+                continue
+            if tokens_lower[i:i + length] == phrase_tokens:
+                if i > 0 and tokens_lower[i - 1] in NEGATIONS:
+                    continue
+                tags.append((info["tag"], info.get("category", "misc")))
+                for j in range(length):
+                    used.add(i + j)
+
+    # process single words
+    for i, token in enumerate(doc):
+        if i in used:
+            continue
+        word = token.text.lower()
+        if word in word_tags and not is_negated(token):
+            info = word_tags[word]
+            tags.append((info["tag"], info.get("category", "misc")))
+
+    # deduplicate
+    seen = set()
+    unique_tags = []
+    for tag, cat in tags:
+        if tag not in seen:
+            seen.add(tag)
+            unique_tags.append((tag, cat))
+
+    # sort by category order
+    unique_tags.sort(key=lambda x: CATEGORIES_ORDER.index(x[1]) if x[1] in CATEGORIES_ORDER else len(CATEGORIES_ORDER))
+    return unique_tags
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert natural language to danbooru tags")
+    parser.add_argument("text", nargs="*", help="Input description")
+    parser.add_argument("--tags", default="tags.json", help="Path to tags JSON file")
+    args = parser.parse_args()
+
+    if args.text:
+        input_text = " ".join(args.text)
+    else:
+        input_text = input("Enter description: ")
+
+    words, phrases = load_tags(Path(args.tags))
+    extracted = extract_tags(input_text, words, phrases)
+    output = ", ".join(tag for tag, _ in extracted)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tags.json
+++ b/tags.json
@@ -1,0 +1,31 @@
+{
+  "phrases": {
+    "long hair": {"tag": "long_hair", "category": "hair"},
+    "short hair": {"tag": "short_hair", "category": "hair"},
+    "blue eyes": {"tag": "blue_eyes", "category": "eyes"},
+    "red eyes": {"tag": "red_eyes", "category": "eyes"},
+    "green eyes": {"tag": "green_eyes", "category": "eyes"},
+    "black hair": {"tag": "black_hair", "category": "hair"},
+    "brown hair": {"tag": "brown_hair", "category": "hair"},
+    "blonde hair": {"tag": "blonde_hair", "category": "hair"}
+  },
+  "words": {
+    "girl": {"tag": "1girl", "category": "person"},
+    "boy": {"tag": "1boy", "category": "person"},
+    "smile": {"tag": "smile", "category": "emotion"},
+    "smiling": {"tag": "smile", "category": "emotion"},
+    "happy": {"tag": "smile", "category": "emotion"},
+    "weapon": {"tag": "weapon", "category": "object"},
+    "sword": {"tag": "sword", "category": "object"},
+    "gun": {"tag": "gun", "category": "object"},
+    "cat": {"tag": "cat", "category": "animal"},
+    "dog": {"tag": "dog", "category": "animal"},
+    "tree": {"tag": "tree", "category": "environment"},
+    "outdoor": {"tag": "outdoors", "category": "environment"},
+    "indoor": {"tag": "indoors", "category": "environment"},
+    "standing": {"tag": "standing", "category": "position"},
+    "sitting": {"tag": "sitting", "category": "position"},
+    "blush": {"tag": "blush", "category": "emotion"},
+    "blushing": {"tag": "blush", "category": "emotion"}
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `tag_converter.py` script that parses natural language with spaCy
- load danbooru tags from an external `tags.json` file
- document how to run the new converter in `README.md`

## Testing
- `python tag_converter.py "A happy girl with blue eyes and long hair"` *(fails: ModuleNotFoundError: No module named 'spacy')*
- `python danbooru_prompt_app.py "A happy girl with long hair and blue eyes"`

------
https://chatgpt.com/codex/tasks/task_e_68411940bdf48325ac7f8279bf08847b