### PR TITLE
Add Japanese comments and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # TEST
 
-テスト
+このリポジトリには、danbooru 形式のタグを用いて Stable Diffusion 向けプロンプトを生成するスクリプトが含まれています。
 
-This repository contains a simple script to help generate Stable Diffusion prompts
-using danbooru-style tags.
+## 使い方
 
-## Usage
+利用できるスクリプトは次の 2 つです。
 
-Run the script with a description of the desired image:
+1. **danbooru_prompt_app.py** - 単純な単語やフレーズを置き換えるだけの変換ツール。
+2. **tag_converter.py** - `tags.json` を読み込み、spaCy で英文を解析してタグを抽出します。
+
+### tag_converter.py の実行例
 
 ```bash
-python danbooru_prompt_app.py "A smiling girl with long hair and blue eyes"
+python tag_converter.py "A happy girl with blue eyes and long hair"
 ```
 
-The script will output a comma-separated list of tags that can be used as a
-prompt for Stable Diffusion.
+実行すると、使用可能なタグがカンマ区切りで表示されます。
+事前に `pip install spacy` と `python -m spacy download en_core_web_sm` を実行して spaCy と英語モデルをインストールしてください。

--- a/danbooru_prompt_app.py
+++ b/danbooru_prompt_app.py
@@ -1,7 +1,7 @@
 import argparse
 import re
 
-# Mapping from words to danbooru tags
+# 単語から danbooru タグへのマッピング
 WORD_TAGS = {
     "girl": "1girl",
     "boy": "1boy",
@@ -22,7 +22,7 @@ WORD_TAGS = {
     "blushing": "blush",
 }
 
-# Mapping from multi-word phrases to danbooru tags
+# 複数語フレーズから danbooru タグへのマッピング
 PHRASE_TAGS = {
     "long hair": "long_hair",
     "short hair": "short_hair",
@@ -35,23 +35,23 @@ PHRASE_TAGS = {
 }
 
 def generate_prompt(text: str) -> str:
-    """Convert input text to a comma-separated list of danbooru tags."""
+    """入力テキストを danbooru タグのカンマ区切りリストに変換する"""
     text = text.lower()
     tags = []
 
-    # Detect phrases first
+    # 最初にフレーズを検出する
     for phrase, tag in PHRASE_TAGS.items():
         if phrase in text:
             tags.append(tag)
             text = text.replace(phrase, " ")
 
-    # Process single words
+    # 単語を処理する
     tokens = re.findall(r"\b\w+\b", text)
     for token in tokens:
         if token in WORD_TAGS:
             tags.append(WORD_TAGS[token])
 
-    # Remove duplicates while preserving order
+    # 順序を保ったまま重複を除去する
     seen = set()
     unique_tags = []
     for tag in tags:
@@ -63,14 +63,14 @@ def generate_prompt(text: str) -> str:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Convert text to danbooru tags for Stable Diffusion prompts")
-    parser.add_argument("text", nargs="*", help="Input description")
+    parser = argparse.ArgumentParser(description="Stable Diffusion 用の danbooru タグへ変換する")
+    parser.add_argument("text", nargs="*", help="入力する説明文")
     args = parser.parse_args()
 
     if args.text:
         input_text = " ".join(args.text)
     else:
-        input_text = input("Enter description: ")
+        input_text = input("説明文を入力してください: ")
 
     prompt = generate_prompt(input_text)
     print(prompt)

--- a/tag_converter.py
+++ b/tag_converter.py
@@ -1,0 +1,115 @@
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import spacy
+
+# 英語モデルを読み込む
+try:
+    nlp = spacy.load("en_core_web_sm")
+except OSError:
+    # モデルがインストールされていない場合
+    nlp = spacy.blank("en")
+
+NEGATIONS = {"no", "not", "without", "n't"}
+
+CATEGORIES_ORDER = [
+    "person",
+    "hair",
+    "eyes",
+    "emotion",
+    "position",
+    "object",
+    "animal",
+    "environment",
+    "misc",
+]
+
+
+def load_tags(path: Path) -> Tuple[Dict[str, Dict[str, str]], Dict[str, Dict[str, str]]]:
+    """JSON ファイルからタグ辞書を読み込む"""
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("words", {}), data.get("phrases", {})
+
+
+def is_negated(token) -> bool:
+    """トークンが文中で否定されている場合 True を返す"""
+    if token.i > 0 and token.doc[token.i - 1].lower_ in NEGATIONS:
+        return True
+    # 否定表現の子要素や祖先を確認する
+    for child in token.children:
+        if child.dep_ == "neg" or child.lower_ in NEGATIONS:
+            return True
+    for ancestor in token.ancestors:
+        for child in ancestor.children:
+            if child.dep_ == "neg" or child.lower_ in NEGATIONS:
+                return True
+    return False
+
+
+def extract_tags(text: str, word_tags: Dict[str, Dict[str, str]], phrase_tags: Dict[str, Dict[str, str]]) -> List[Tuple[str, str]]:
+    text_lower = text.lower()
+    doc = nlp(text_lower)
+    tokens_lower = [t.text.lower() for t in doc]
+    used = set()
+    tags: List[Tuple[str, str]] = []
+
+    # フレーズは長いものから優先して処理する
+    phrases_sorted = sorted(phrase_tags.items(), key=lambda x: len(x[0].split()), reverse=True)
+    for phrase, info in phrases_sorted:
+        phrase_tokens = phrase.split()
+        length = len(phrase_tokens)
+        for i in range(len(doc) - length + 1):
+            if any((i + j) in used for j in range(length)):
+                continue
+            if tokens_lower[i:i + length] == phrase_tokens:
+                if i > 0 and tokens_lower[i - 1] in NEGATIONS:
+                    continue
+                tags.append((info["tag"], info.get("category", "misc")))
+                for j in range(length):
+                    used.add(i + j)
+
+    # 単語を処理する
+    for i, token in enumerate(doc):
+        if i in used:
+            continue
+        word = token.text.lower()
+        if word in word_tags and not is_negated(token):
+            info = word_tags[word]
+            tags.append((info["tag"], info.get("category", "misc")))
+
+    # 重複を除去する
+    seen = set()
+    unique_tags = []
+    for tag, cat in tags:
+        if tag not in seen:
+            seen.add(tag)
+            unique_tags.append((tag, cat))
+
+    # カテゴリ順にソートする
+    unique_tags.sort(key=lambda x: CATEGORIES_ORDER.index(x[1]) if x[1] in CATEGORIES_ORDER else len(CATEGORIES_ORDER))
+    return unique_tags
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="自然文から danbooru タグを生成する")
+    parser.add_argument("text", nargs="*", help="入力する説明文")
+    parser.add_argument("--tags", default="tags.json", help="タグ定義 JSON のパス")
+    args = parser.parse_args()
+
+    if args.text:
+        input_text = " ".join(args.text)
+    else:
+        input_text = input("説明文を入力してください: ")
+
+    words, phrases = load_tags(Path(args.tags))
+    extracted = extract_tags(input_text, words, phrases)
+    output = ", ".join(tag for tag, _ in extracted)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tags.json
+++ b/tags.json
@@ -1,0 +1,31 @@
+{
+  "phrases": {
+    "long hair": {"tag": "long_hair", "category": "hair"},
+    "short hair": {"tag": "short_hair", "category": "hair"},
+    "blue eyes": {"tag": "blue_eyes", "category": "eyes"},
+    "red eyes": {"tag": "red_eyes", "category": "eyes"},
+    "green eyes": {"tag": "green_eyes", "category": "eyes"},
+    "black hair": {"tag": "black_hair", "category": "hair"},
+    "brown hair": {"tag": "brown_hair", "category": "hair"},
+    "blonde hair": {"tag": "blonde_hair", "category": "hair"}
+  },
+  "words": {
+    "girl": {"tag": "1girl", "category": "person"},
+    "boy": {"tag": "1boy", "category": "person"},
+    "smile": {"tag": "smile", "category": "emotion"},
+    "smiling": {"tag": "smile", "category": "emotion"},
+    "happy": {"tag": "smile", "category": "emotion"},
+    "weapon": {"tag": "weapon", "category": "object"},
+    "sword": {"tag": "sword", "category": "object"},
+    "gun": {"tag": "gun", "category": "object"},
+    "cat": {"tag": "cat", "category": "animal"},
+    "dog": {"tag": "dog", "category": "animal"},
+    "tree": {"tag": "tree", "category": "environment"},
+    "outdoor": {"tag": "outdoors", "category": "environment"},
+    "indoor": {"tag": "indoors", "category": "environment"},
+    "standing": {"tag": "standing", "category": "position"},
+    "sitting": {"tag": "sitting", "category": "position"},
+    "blush": {"tag": "blush", "category": "emotion"},
+    "blushing": {"tag": "blush", "category": "emotion"}
+  }
+}


### PR DESCRIPTION
## Summary
- 日本語で README を記述
- 既存のスクリプトのコメントおよびヘルプ文を日本語化

## Testing
- ❌ `python tag_converter.py "A happy girl with blue eyes and long hair"`
- ✅ `python danbooru_prompt_app.py "A happy girl with long hair and blue eyes"`


------
https://chatgpt.com/codex/tasks/task_e_68411940bdf48325ac7f8279bf08847b