### PR TITLE
Add tag converter with language detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,36 @@
-# TEST
+# タグ変換ツール
 
-このリポジトリには、danbooru 形式のタグを用いて Stable Diffusion 向けプロンプトを生成するスクリプトが含まれています。
+`tag_converter.py` は英語または日本語のキャプションを Danbooru タグの一覧に変換します。
+
+## インストール
+
+1. Python 3.9 以降を用意してください。
+2. 必要なパッケージをインストールします。
+   ```bash
+   pip install spacy langdetect
+   python -m spacy download en_core_web_sm
+   python -m spacy download ja_core_news_sm
+   ```
 
 ## 使い方
 
-利用できるスクリプトは次の 2 つです。
-
-1. **danbooru_prompt_app.py** - 単純な単語やフレーズを置き換えるだけの変換ツール。
-2. **tag_converter.py** - `tags.json` を読み込み、spaCy で英文を解析してタグを抽出します。
-
-### tag_converter.py の実行例
+キャプションをコマンドライン引数で渡すか、指定しない場合は標準入力から入力します。
 
 ```bash
-python tag_converter.py "A happy girl with blue eyes and long hair"
+python tag_converter.py "A happy girl with long hair and blue eyes"
+python tag_converter.py --lang auto "笑顔の茶髪の女の子"
 ```
 
-実行すると、使用可能なタグがカンマ区切りで表示されます。
-事前に `pip install spacy` と `python -m spacy download en_core_web_sm` を実行して spaCy と英語モデルをインストールしてください。
+実行すると、対応する Danbooru タグをカンマ区切りで表示します。
+
+### 辞書の拡張
+
+タグの定義は `tags_en.json` と `tags_ja.json` にあります。各エントリは単語やフレーズ（小文字）を Danbooru タグと任意のカテゴリに対応させます。
+
+```json
+{
+  "long hair": {"tag": "long_hair", "category": "hair"}
+}
+```
+
+新しい単語やフレーズを認識させたい場合は、これらのファイルに追記してください。

--- a/tags_en.json
+++ b/tags_en.json
@@ -1,0 +1,8 @@
+{
+  "girl": {"tag": "1girl", "category": "count/people"},
+  "boy": {"tag": "1boy", "category": "count/people"},
+  "long hair": {"tag": "long_hair", "category": "hair"},
+  "blue eyes": {"tag": "blue_eyes", "category": "eyes"},
+  "smile": {"tag": "smile", "category": "expression"},
+  "running": {"tag": "running", "category": "pose/action"}
+}

--- a/tags_ja.json
+++ b/tags_ja.json
@@ -1,0 +1,8 @@
+{
+  "女の子": {"tag": "1girl", "category": "count/people"},
+  "男の子": {"tag": "1boy", "category": "count/people"},
+  "長髪": {"tag": "long_hair", "category": "hair"},
+  "青い目": {"tag": "blue_eyes", "category": "eyes"},
+  "笑顔": {"tag": "smile", "category": "expression"},
+  "茶髪": {"tag": "brown_hair", "category": "hair"}
+}


### PR DESCRIPTION
## Summary
- add new tag_converter with language detection and ordered tagging
- provide minimal tag dictionaries for English and Japanese
- document installation and usage in README
- translate comments and README to Japanese

## Testing
- `python -m py_compile tag_converter.py`


------
https://chatgpt.com/codex/tasks/task_e_6841c2cf23888325a5574c4a169566e4